### PR TITLE
use curl instead of ping to check network, permit https

### DIFF
--- a/cloud-config/master-config.yaml
+++ b/cloud-config/master-config.yaml
@@ -130,7 +130,7 @@ coreos:
         User=root
         PermissionsStartOnly=true
         ExecStartPre=-/usr/bin/wget -N -P "/home/core" "https://github.com/Metaswitch/calico-docker/releases/download/v0.5.1/calicoctl"
-        ExecStartPre=-chmod +x /home/core/calicoctl
+        ExecStartPre=chmod +x /home/core/calicoctl
         ExecStart=/home/core/calico-node.sh $DEFAULT_IPV4
         RemainAfterExit=yes
         Type=oneshot

--- a/cloud-config/master-config.yaml
+++ b/cloud-config/master-config.yaml
@@ -14,7 +14,7 @@ write_files:
     owner: root
     permissions: 0755
     content: |
-      #  Location of the kubernetes binaries e.g. http(s)://yourserver.net/path/to/files
+      # Location of the kubernetes binaries e.g. http(s)://yourserver.net/path/to/files
       KUBERNETES_LOC=<KUBERNETES_LOC>
 
   - path: /home/core/kubernetes-download.sh

--- a/cloud-config/master-config.yaml
+++ b/cloud-config/master-config.yaml
@@ -14,7 +14,7 @@ write_files:
     owner: root
     permissions: 0755
     content: |
-      # Location of the kubernetes binaries.
+      #  Location of the kubernetes binaries e.g. http(s)://yourserver.net/path/to/files
       KUBERNETES_LOC=<KUBERNETES_LOC>
 
   - path: /home/core/kubernetes-download.sh
@@ -23,13 +23,13 @@ write_files:
     content: |
       #! /usr/bin/bash
       # Network not always up, ping to wait for internet connection
-      while ! ping -c 1 $KUBERNETES_LOC; do :; done
+      while [[ $(curl --silent  --connect-timeout 2 $KUBERNETES_LOC/test 2>&1>/dev/null ; echo $?) -ne 0 ]] ; do :; sleep 2 ; done
       # Download kubernetes binaries from the following location.
-      /usr/bin/wget -N -P "/home/core" "http://$KUBERNETES_LOC/kubectl"
-      /usr/bin/wget -N -P "/home/core" "http://$KUBERNETES_LOC/kubernetes"
-      /usr/bin/wget -N -P "/home/core" "http://$KUBERNETES_LOC/kube-controller-manager"
-      /usr/bin/wget -N -P "/home/core" "http://$KUBERNETES_LOC/kube-apiserver"
-      /usr/bin/wget -N -P "/home/core" "http://$KUBERNETES_LOC/kube-scheduler"
+      /usr/bin/wget -N -P "/home/core" "$KUBERNETES_LOC/kubectl"
+      /usr/bin/wget -N -P "/home/core" "$KUBERNETES_LOC/kubernetes"
+      /usr/bin/wget -N -P "/home/core" "$KUBERNETES_LOC/kube-controller-manager"
+      /usr/bin/wget -N -P "/home/core" "$KUBERNETES_LOC/kube-apiserver"
+      /usr/bin/wget -N -P "/home/core" "$KUBERNETES_LOC/kube-scheduler"
       sudo chmod +x /home/core/*
 
   - path: /home/core/calico-node.sh

--- a/cloud-config/node-config.yaml
+++ b/cloud-config/node-config.yaml
@@ -39,9 +39,8 @@ write_files:
       # Download kubernetes binaries from the following location.
       /usr/bin/wget -N -P "/home/core" "$KUBERNETES_LOC/kubectl"
       /usr/bin/wget -N -P "/home/core" "$KUBERNETES_LOC/kubernetes"
-      /usr/bin/wget -N -P "/home/core" "$KUBERNETES_LOC/kube-controller-manager"
-      /usr/bin/wget -N -P "/home/core" "$KUBERNETES_LOC/kube-apiserver"
-      /usr/bin/wget -N -P "/home/core" "$KUBERNETES_LOC/kube-scheduler"
+      /usr/bin/wget -N -P "/home/core" "$KUBERNETES_LOC/kube-proxy"
+      /usr/bin/wget -N -P "/home/core" "$KUBERNETES_LOC/kubelet"
       sudo chmod +x /home/core/*
 
   - path: /home/core/calico-node.sh
@@ -115,9 +114,7 @@ coreos:
         After=network-online.target
 
         [Service]
-        ExecStartPre=-/usr/bin/mkdir -p /opt/bin
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://github.com/kelseyhightower/setup-network-environment/releases/download/v1.0.0/setup-network-environment
-        ExecStartPre=/usr/bin/chmod +x /opt/bin/setup-network-environment
+        ExecStartPre=/bin/bash -c '[[ ! -f /opt/bin/setup-network-environment ]] && /usr/bin/mkdir -p /opt/bin && /usr/bin/wget -N -P /opt/bin https://github.com/kelseyhightower/setup-network-environment/releases/download/v1.0.0/setup-network-environment && /usr/bin/chmod +x /opt/bin/setup-network-environment'
         ExecStart=/opt/bin/setup-network-environment
         RemainAfterExit=yes
         Type=oneshot
@@ -136,8 +133,7 @@ coreos:
         EnvironmentFile=/etc/other-environment
         User=root
         PermissionsStartOnly=true
-        ExecStartPre=-/usr/bin/wget -N -P "/home/core" "https://github.com/Metaswitch/calico-docker/releases/download/v0.5.1/calicoctl"
-        ExecStartPre=-/usr/bin/chmod +x /home/core/calicoctl
+        ExecStartPre=/bin/bash -c '[[ ! -f /home/core/calicoctl ]] && /usr/bin/wget -N -P "/home/core" "https://github.com/Metaswitch/calico-docker/releases/download/v0.5.1/calicoctl" && /usr/bin/chmod +x /home/core/calicoctl'
         ExecStart=/home/core/calico-node.sh $DEFAULT_IPV4 $ETCD_AUTHORITY
         RemainAfterExit=yes
         Type=oneshot

--- a/cloud-config/node-config.yaml
+++ b/cloud-config/node-config.yaml
@@ -14,7 +14,7 @@ write_files:
     owner: root
     permissions: 0755
     content: |      
-      # Location from which to download the Kubernetes binaries
+      # Location of the kubernetes binaries e.g. http(s)://yourserver.net/path/to/files
       KUBERNETES_LOC=<KUBERNETES_LOC>
 
       # The kubernetes master IP
@@ -35,12 +35,13 @@ write_files:
     content: |
       #! /usr/bin/bash
       # Network not always up, ping to wait for internet connection
-      while ! ping -c 1 $KUBERNETES_LOC; do :; done
-      # Download kubernetes binaries
-      /usr/bin/wget -N -P "/home/core" "http://$KUBERNETES_LOC/kubectl"
-      /usr/bin/wget -N -P "/home/core" "http://$KUBERNETES_LOC/kubernetes"
-      /usr/bin/wget -N -P "/home/core" "http://$KUBERNETES_LOC/kube-proxy"
-      /usr/bin/wget -N -P "/home/core" "http://$KUBERNETES_LOC/kubelet"
+      while [[ $(curl --silent  --connect-timeout 2 $KUBERNETES_LOC/test 2>&1>/dev/null ; echo $?) -ne 0 ]] ; do :; sleep 2 ; done
+      # Download kubernetes binaries from the following location.
+      /usr/bin/wget -N -P "/home/core" "$KUBERNETES_LOC/kubectl"
+      /usr/bin/wget -N -P "/home/core" "$KUBERNETES_LOC/kubernetes"
+      /usr/bin/wget -N -P "/home/core" "$KUBERNETES_LOC/kube-controller-manager"
+      /usr/bin/wget -N -P "/home/core" "$KUBERNETES_LOC/kube-apiserver"
+      /usr/bin/wget -N -P "/home/core" "$KUBERNETES_LOC/kube-scheduler"
       sudo chmod +x /home/core/*
 
   - path: /home/core/calico-node.sh


### PR DESCRIPTION
the ping method fails if the webserver is on a non-standard port, and the current method doesn't support https.  
